### PR TITLE
Commenting out PyFluent extra packages (temp solution)

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,10 +8,6 @@
    PyMAPDL <https://mapdl.docs.pyansys.com/>
    PyMAPDL Reader <https://reader.docs.pyansys.com/>
    PyFluent <https://fluent.docs.pyansys.com/>
-   ..
-      PyFluent-Parametric <https://fluentparametric.docs.pyansys.com/>
-      PyFluent-Visualization <https://fluentvisualization.docs.pyansys.com/>
-
    PyPIM <https://pypim.docs.pyansys.com/>
    Granta MI BoM Analytics <https://grantami.docs.pyansys.com/>
    Shared Components <https://shared.docs.pyansys.com/>

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,6 +11,7 @@
    ..
       PyFluent-Parametric <https://fluentparametric.docs.pyansys.com/>
       PyFluent-Visualization <https://fluentvisualization.docs.pyansys.com/>
+
    PyPIM <https://pypim.docs.pyansys.com/>
    Granta MI BoM Analytics <https://grantami.docs.pyansys.com/>
    Shared Components <https://shared.docs.pyansys.com/>

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,8 +8,8 @@
    PyMAPDL <https://mapdl.docs.pyansys.com/>
    PyMAPDL Reader <https://reader.docs.pyansys.com/>
    PyFluent <https://fluent.docs.pyansys.com/>
-   PyFluent-Parametric <https://fluentparametric.docs.pyansys.com/>
-   PyFluent-Visualization <https://fluentvisualization.docs.pyansys.com/>
+   .. PyFluent-Parametric <https://fluentparametric.docs.pyansys.com/>
+   .. PyFluent-Visualization <https://fluentvisualization.docs.pyansys.com/>
    PyPIM <https://pypim.docs.pyansys.com/>
    Granta MI BoM Analytics <https://grantami.docs.pyansys.com/>
    Shared Components <https://shared.docs.pyansys.com/>

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,8 +8,9 @@
    PyMAPDL <https://mapdl.docs.pyansys.com/>
    PyMAPDL Reader <https://reader.docs.pyansys.com/>
    PyFluent <https://fluent.docs.pyansys.com/>
-   .. PyFluent-Parametric <https://fluentparametric.docs.pyansys.com/>
-   .. PyFluent-Visualization <https://fluentvisualization.docs.pyansys.com/>
+   ..
+      PyFluent-Parametric <https://fluentparametric.docs.pyansys.com/>
+      PyFluent-Visualization <https://fluentvisualization.docs.pyansys.com/>
    PyPIM <https://pypim.docs.pyansys.com/>
    Granta MI BoM Analytics <https://grantami.docs.pyansys.com/>
    Shared Components <https://shared.docs.pyansys.com/>


### PR DESCRIPTION
Adding the PyFluent extra packages "destroyed" our top navbar. Commenting them out temporarily until we find a solution.